### PR TITLE
Rename functions conflicting with upstream edk

### DIFF
--- a/DcsCfg/DcsCfgCrypt.c
+++ b/DcsCfg/DcsCfgCrypt.c
@@ -1601,7 +1601,7 @@ UsbScApdu(
 	EFI_STATUS res;
 	CE(InitUsb());
 	CE(UsbGetIO(gUSBHandles[UsbIndex], &UsbIo));
-	StrHexToBytes(cmd + sizeof(CCID_HEADER_OUT), &cmdLen, hexString);
+	DcsStrHexToBytes(cmd + sizeof(CCID_HEADER_OUT), &cmdLen, hexString);
 	CE(UsbScTransmit(UsbIo, cmd, cmdLen + sizeof(CCID_HEADER_OUT), resp, &respLen, &statusSc));
 	PrintBytes(resp, respLen);
 	return res;

--- a/DcsInt/DcsInt.c
+++ b/DcsInt/DcsInt.c
@@ -869,7 +869,7 @@ OnExit(
 	if (action == NULL) return retValue;
 	if (OnExitGetParam(action, "guid", &guidStr, NULL)) {
 		EFI_GUID tmp;
-		if (AsciiStrToGuid(&tmp, guidStr)) {
+		if (DcsAsciiStrToGuid(&tmp, guidStr)) {
 			guid = MEM_ALLOC(sizeof(EFI_GUID));
 			CopyMem(guid, &tmp, sizeof(EFI_GUID));
 		}

--- a/Include/Library/CommonLib.h
+++ b/Include/Library/CommonLib.h
@@ -412,7 +412,7 @@ AsciiHexToByte(
 	);
 
 BOOLEAN
-AsciiStrToGuid(
+DcsAsciiStrToGuid(
 	OUT EFI_GUID  *guid, 
 	IN  CHAR8     *str
 	);
@@ -425,7 +425,7 @@ AsciiHexToBytes(
 	);
 
 BOOLEAN
-StrHexToBytes(
+DcsStrHexToBytes(
 	OUT UINT8  *b,
 	IN  UINTN  *bytesLen,
 	IN  CHAR16  *str

--- a/Library/CommonLib/EfiConsole.c
+++ b/Library/CommonLib/EfiConsole.c
@@ -366,7 +366,7 @@ AsciiHexToByte(
 }
 
 BOOLEAN
-AsciiStrToGuid(
+DcsAsciiStrToGuid(
 	OUT EFI_GUID  *guid,
 	IN  CHAR8     *str
 	)
@@ -428,7 +428,7 @@ AsciiHexToBytes(
 }
 
 BOOLEAN
-StrHexToBytes(
+DcsStrHexToBytes(
 	OUT UINT8  *b,
 	IN  UINTN  *bytesLen,
 	IN  CHAR16  *str

--- a/Library/DcsCfgLib/GptEdit.c
+++ b/Library/DcsCfgLib/GptEdit.c
@@ -636,7 +636,7 @@ GptAskGUID(
 		ok = TRUE;
 	}
 	else {
-		ok = AsciiStrToGuid(&result, buf);
+		ok = DcsAsciiStrToGuid(&result, buf);
 		if (ok) {
 			CopyMem(guid, &result, sizeof(result));
 		}

--- a/Library/VeraCryptLib/DcsVeraCrypt.c
+++ b/Library/VeraCryptLib/DcsVeraCrypt.c
@@ -186,7 +186,7 @@ VCAuthLoadConfig()
 	ConfigReadString("PartitionGuidOS", "", strTemp, MAX_MSG);
 	if (strTemp[0] != 0) {
 		EFI_GUID g;
-		if (AsciiStrToGuid(&g, strTemp)) {
+		if (DcsAsciiStrToGuid(&g, strTemp)) {
 			VCCONFIG_ALLOC(gPartitionGuidOS, sizeof(EFI_GUID));
 			if (gPartitionGuidOS != NULL) {
 				memcpy(gPartitionGuidOS, &g, sizeof(g));


### PR DESCRIPTION
This commit renames functions whose name clashes with functions newly implemented in upstream EDK II.
Discussed at https://sourceforge.net/p/veracrypt/tickets/259/.