### PR TITLE
Fix variable declaration hiding previous declaration

### DIFF
--- a/Library/PasswordLib/PicturePassword.c
+++ b/Library/PasswordLib/PicturePassword.c
@@ -285,7 +285,6 @@ AskPictPwdInt(
 	CHAR8          pwdNewChar = 0;
 
 	if (gPasswordTimeout) {
-		UINTN          EventIndex = 0;
 		InputEvents[0] = gST->ConIn->WaitForKey;
 		eventsCount = 2;
 		if (gTouchPointer != NULL) {


### PR DESCRIPTION
This patch removes duplicit declaration of `EventIndex` variable, which resulted in warning _declaration of 'EventIndex' hides previous local declaration_ under VS2017 toolset (#13). Since warnings are treated as errors this failed the build.