### PR TITLE
Add -osundecrypt flag

### DIFF
--- a/DcsCfg/DcsCfg.h
+++ b/DcsCfg/DcsCfg.h
@@ -59,6 +59,9 @@ EFI_STATUS
 OSDecrypt();
 
 EFI_STATUS
+OSUndecrypt();
+
+EFI_STATUS
 VolumeChangePassword(
 	IN UINTN index);
 

--- a/DcsCfg/DcsCfg.man
+++ b/DcsCfg/DcsCfg.man
@@ -75,6 +75,7 @@ DcsCfg -ds <BN> -wipe <start> <end>
 
 ** Rescue
  -osdecrypt - decrypt OS (rescue)
+ -osundecrypt - undecrypt OS (rescue)
  -osrestorekey - restore key (rescue)
 
 ** TPM

--- a/DcsCfg/DcsCfgMain.c
+++ b/DcsCfg/DcsCfgMain.c
@@ -86,6 +86,7 @@ https://opensource.org/licenses/LGPL-3.0
 #define OPT_WIPE							L"-wipe"
 
 #define OPT_OS_DECRYPT					L"-osdecrypt"
+#define OPT_OS_UNDECRYPT				L"-osundecrypt"
 #define OPT_OS_RESTORE_KEY				L"-osrestorekey"
 
 #define OPT_TPM_PCRS						L"-tpmpcrs"
@@ -157,6 +158,7 @@ STATIC CONST SHELL_PARAM_ITEM ParamList[] = {
 	{ OPT_SECREGION_DUMP,       TypeValue },
 	{ OPT_WIPE,                 TypeDoubleValue },
 	{ OPT_OS_DECRYPT,     TypeFlag },
+	{ OPT_OS_UNDECRYPT,   TypeFlag },
 	{ OPT_OS_RESTORE_KEY, TypeFlag },
 	{ OPT_OS_HIDE_PREP,   TypeFlag },
 	{ OPT_TPM_PCRS,       TypeDoubleValue },
@@ -215,6 +217,9 @@ DcsCfgMain(
 		if (StrStr(cmd, OPT_OS_DECRYPT) != NULL) {
 			return OSDecrypt();
 		}
+		if (StrStr(cmd, OPT_OS_UNDECRYPT) != NULL) {
+			return OSUndecrypt();
+		}
 		return EFI_INVALID_PARAMETER;
 	}
 
@@ -269,6 +274,10 @@ DcsCfgMain(
 	// Rescue
 	if (ShellCommandLineGetFlag(Package, OPT_OS_DECRYPT)) {
 		return OSDecrypt();
+	}
+
+	if (ShellCommandLineGetFlag(Package, OPT_OS_UNDECRYPT)) {
+		return OSUndecrypt();
 	}
 
 	if (ShellCommandLineGetFlag(Package, OPT_OS_RESTORE_KEY)) {

--- a/DcsRe/DcsRe.c
+++ b/DcsRe/DcsRe.c
@@ -297,9 +297,11 @@ ActionRestoreDcsProp(IN VOID* ctx) {
 }
 
 #define OPT_OS_DECRYPT L"-osdecrypt"
+#define OPT_OS_UNDECRYPT L"-osundecrypt"
 #define OPT_OS_RESTORE_KEY L"-osrestorekey"
 
 CHAR16* sOSDecrypt = OPT_OS_DECRYPT;
+CHAR16* sOSUndecrypt = OPT_OS_UNDECRYPT;
 CHAR16* sOSRestoreKey = OPT_OS_RESTORE_KEY;
 CHAR16* sDcsCfg = L"EFI\\VeraCrypt\\DcsCfg.dcs";
 
@@ -314,6 +316,13 @@ EFI_STATUS
 ActionDecryptOS(IN VOID* ctx) {
 	EFI_STATUS res = EFI_NOT_READY;
 	res = EfiSetVar(L"dcscfgcmd", NULL, sOSDecrypt, StrSize(sOSDecrypt), EFI_VARIABLE_BOOTSERVICE_ACCESS);
+	return EfiExec(NULL, sDcsCfg);
+}
+
+EFI_STATUS
+ActionUndecryptOS(IN VOID* ctx) {
+	EFI_STATUS res = EFI_NOT_READY;
+	res = EfiSetVar(L"dcscfgcmd", NULL, sOSUndecrypt, StrSize(sOSUndecrypt), EFI_VARIABLE_BOOTSERVICE_ACCESS);
 	return EfiExec(NULL, sDcsCfg);
 }
 


### PR DESCRIPTION
This PR is in response to https://sourceforge.net/p/veracrypt/discussion/technical/thread/db6f914347/

It adds an `-osundecrypt` flag to `DcsCfg`, which is meant to be the opposite of `-osdecrypt`.
I didn't name it `-osencrypt` because that seemed to imply encryption of a system with no initialized header.